### PR TITLE
Refactor Granite API service to utilize OpenRouter API, replacing IBM integration

### DIFF
--- a/granite-api-service/README.md
+++ b/granite-api-service/README.md
@@ -1,0 +1,34 @@
+# Granite API Service (now using OpenRouter)
+
+This service generates marketing content using the OpenRouter API (https://openrouter.ai/), replacing the previous IBM Granite integration.
+
+## Environment Variables
+
+Create a `.env` file in this directory with the following:
+
+```
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+OPENROUTER_MODEL=openai/gpt-4o
+PORT=5000
+```
+
+- `OPENROUTER_API_KEY`: Your API key from https://openrouter.ai/
+- `OPENROUTER_MODEL`: (Optional) The model to use, e.g., `deepseek/deepseek-r1:free` (default)
+- `PORT`: (Optional) Port to run the service (default: 5000)
+
+## Usage
+
+Start the service:
+
+```
+npm install
+npm start
+```
+
+The main endpoint is:
+
+- `POST /api/dashboard/post` — Generates two marketing campaign variations and estimates metrics using OpenRouter.
+
+## Notes
+- This service no longer uses IBM/Granite models or authentication.
+- All content and metrics estimation is now powered by OpenRouter-compatible models. 

--- a/granite-api-service/package.json
+++ b/granite-api-service/package.json
@@ -10,7 +10,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": "",
+  "description": "API service for marketing content generation using OpenRouter API (formerly Granite/IBM)",
   "dependencies": {
     "axios": "^1.10.0",
     "cors": "^2.8.5",

--- a/render.yaml
+++ b/render.yaml
@@ -6,5 +6,5 @@ services:
     buildCommand: npm install
     startCommand: npm start
     envVars:
-      - key: IBM_API_KEY
+      - key: OPENROUTER_API_KEY
         sync: false


### PR DESCRIPTION
Updated environment variables, modified content generation and metrics estimation logic, and added README documentation for setup and usage. 
The service now requires OPENROUTER_API_KEY and supports customizable model selection.